### PR TITLE
Mixed (dashed and solid) center lines

### DIFF
--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -37,6 +37,19 @@ bool tryGet(const json& j, std::string name, T& variable) {
     return true;
 }
 
+static std::string lineTypeToStr(LaneMarking markingType) {
+    switch (markingType) {
+        case LaneMarking::Dashed:
+            return "Dashed";
+        case LaneMarking::DoubleSolid:
+            return "DoubleSolid";
+        case LaneMarking::DashedAndSolid:
+            return "DashedAndSolid";
+        case LaneMarking::SolidAndDashed:
+            return "SolidAndDashed";
+    }
+}
+
 namespace glm {
 
     /*
@@ -440,30 +453,12 @@ void to_json(json& j, const Tracks& t) {
             jsonTrack["center"] = arc->center;
             jsonTrack["radius"] = arc->radius;
             jsonTrack["rightArc"] = arc->rightArc;
-            switch (arc->centerLine) {
-                case LaneMarking::Dashed: {
-                    jsonTrack["centerLine"] = "Dashed";
-                    break;
-                }
-                case LaneMarking::DoubleSolid: {
-                    jsonTrack["centerLine"] = "DoubleSolid";
-                    break;
-                }
-            }
+            jsonTrack["centerLine"] = lineTypeToStr(arc->centerLine);
         } else {
             std::shared_ptr<TrackLine> line 
                 = std::dynamic_pointer_cast<TrackLine>(track);
             jsonTrack["type"] = "line";
-            switch (line->centerLine) {
-                case LaneMarking::Dashed: {
-                    jsonTrack["centerLine"] = "Dashed";
-                    break;
-                }
-                case LaneMarking::DoubleSolid: {
-                    jsonTrack["centerLine"] = "DoubleSolid";
-                    break;
-                }
-            }
+            jsonTrack["centerLine"] = lineTypeToStr(line->centerLine);
         }
 
         jsonTracks.push_back(jsonTrack);
@@ -546,6 +541,10 @@ void from_json(const json& j, Tracks& t) {
                     arc->centerLine = LaneMarking::Dashed;
                 } else if (centerLine == "DoubleSolid") {
                     arc->centerLine = LaneMarking::DoubleSolid;
+                } else if (centerLine == "DashedAndSolid") {
+                    arc->centerLine = LaneMarking::DashedAndSolid;
+                } else if (centerLine == "SolidAndDashed") {
+                    arc->centerLine = LaneMarking::SolidAndDashed;
                 }
             } catch (json::exception& e) {
                 // use default value
@@ -559,6 +558,10 @@ void from_json(const json& j, Tracks& t) {
                     line->centerLine = LaneMarking::Dashed;
                 } else if (centerLine == "DoubleSolid") {
                     line->centerLine = LaneMarking::DoubleSolid;
+                } else if (centerLine == "DashedAndSolid") {
+                    line->centerLine = LaneMarking::DashedAndSolid;
+                } else if (centerLine == "SolidAndDashed") {
+                    line->centerLine = LaneMarking::SolidAndDashed;
                 }
             } catch (json::exception& e) {
                 // use default value

--- a/src/modules/GuiModule.cpp
+++ b/src/modules/GuiModule.cpp
@@ -763,9 +763,14 @@ void GuiModule::renderSceneWindow(Scene& scene) {
                     if (ImGui::RadioButton("Dashed", *centerLine == LaneMarking::Dashed)) {
                         *centerLine = LaneMarking::Dashed;
                         selection.changed = true;
-                    }
-                    if (ImGui::RadioButton("Double solid", *centerLine == LaneMarking::DoubleSolid)) {
+                    } else if (ImGui::RadioButton("Double solid", *centerLine == LaneMarking::DoubleSolid)) {
                         *centerLine = LaneMarking::DoubleSolid;
+                        selection.changed = true;
+                    } else if (ImGui::RadioButton("Dashed and solid", *centerLine == LaneMarking::DashedAndSolid)) {
+                        *centerLine = LaneMarking::DashedAndSolid;
+                        selection.changed = true;
+                    } else if (ImGui::RadioButton("Solid and dashed", *centerLine == LaneMarking::SolidAndDashed)) {
+                        *centerLine = LaneMarking::SolidAndDashed;
                         selection.changed = true;
                     }
                 }

--- a/src/scene/Tracks.h
+++ b/src/scene/Tracks.h
@@ -20,7 +20,9 @@ struct ControlPoint {
 
 enum struct LaneMarking {
     Dashed,
-    DoubleSolid
+    DoubleSolid,
+    DashedAndSolid,
+    SolidAndDashed // same as above but with reversed order
 };
 
 struct TrackBase {


### PR DESCRIPTION
According to the Carolo-Cup rulebook there is the possibility for mixed center line markings (dashed and solid): 

![grafik](https://user-images.githubusercontent.com/45536968/196233060-2e70ff69-d935-4e1a-ad56-0975b31d9eb0.png)

Our simulator currently only implements the dashed and the double solid options. The third one is now introduced with this MR, leading to the four possibilities shown below:

![grafik](https://user-images.githubusercontent.com/45536968/196233921-7e26af6f-02f8-43fc-8633-e730da03542f.png)

Goals for future MRs:
- reducing duplicate code between line and arc tracks
- adding selection options to hide certain lines
