### PR TITLE
Allow creation of missing lines via the track menu

### DIFF
--- a/src/modules/Editor.h
+++ b/src/modules/Editor.h
@@ -176,10 +176,10 @@ private:
 // model creation
 
     std::shared_ptr<Model> genTrackLineModel(const glm::vec2& start, const glm::vec2& end,
-            const LaneMarking centerLine, const Tracks& tracks);
+            LaneMarking centerLine, bool leftLineMissing, bool rightLineMissing, const Tracks& tracks);
     std::shared_ptr<Model> genTrackArcModel(const glm::vec2& start, const glm::vec2& end,
-            const glm::vec2& center, const float radius, const bool rightArc,
-            const LaneMarking centerLine, const Tracks& tracks);
+            const glm::vec2& center, float radius, bool rightArc,
+            LaneMarking centerLine, bool leftLineMissing, bool rightLineMissing, const Tracks& tracks);
     std::shared_ptr<Model> genTrackIntersectionModel(const TrackIntersection& intersection,
             const Tracks& tracks);
 
@@ -188,11 +188,13 @@ private:
     void genTrackMaterial(Model& model);
 
     void genPointVertices(Model& model);
-    void genTrackLineVertices(const glm::vec2& start, const glm::vec2& end,
-            const LaneMarking centerLine, const Tracks& tracks, Model& model);
+    void genTrackLineVertices(const glm::vec2 &start, const glm::vec2 &end,
+                              LaneMarking centerLine, bool leftLineMissing,
+                              bool rightLineMissing, const Tracks &tracks, Model &model);
     void genTrackArcVertices(const glm::vec2& start, const glm::vec2& end,
-            const glm::vec2& center, const float radius, const bool rightArc,
-            const LaneMarking centerLine, const Tracks& tracks, Model& model);
+            const glm::vec2& center, float radius, bool rightArc,
+            LaneMarking centerLine, bool leftLineMissing,
+            bool rightLineMissing, const Tracks& tracks, Model& model);
     void genTrackIntersectionVertices(const TrackIntersection& intersection,
             const Tracks& tracks, Model& model);
     void genTrackLineMarkerVertices(Model& model);

--- a/src/modules/GuiModule.cpp
+++ b/src/modules/GuiModule.cpp
@@ -750,29 +750,50 @@ void GuiModule::renderSceneWindow(Scene& scene) {
             if (selection.track) {
 
                 LaneMarking* centerLine{nullptr};
+                bool *leftLineMissing{nullptr};
+                bool *rightLineMissing{nullptr};
                 if (std::shared_ptr<TrackLine> line = std::dynamic_pointer_cast<TrackLine>(selection.track)) {
                     centerLine = &line->centerLine;
+                    leftLineMissing = &line->leftLineMissing;
+                    rightLineMissing = &line->rightLineMissing;
                 } else if (std::shared_ptr<TrackArc> arc = std::dynamic_pointer_cast<TrackArc>(selection.track)) {
                     centerLine = &arc->centerLine;
+                    leftLineMissing = &arc->leftLineMissing;
+                    rightLineMissing = &arc->rightLineMissing;
                 }
 
                 if (centerLine) {
-
+                    ImGui::PushID("Center");
                     ImGui::Text("Center line");
 
                     if (ImGui::RadioButton("Dashed", *centerLine == LaneMarking::Dashed)) {
                         *centerLine = LaneMarking::Dashed;
                         selection.changed = true;
-                    } else if (ImGui::RadioButton("Double solid", *centerLine == LaneMarking::DoubleSolid)) {
+                    } else if (ImGui::RadioButton("Double solid",
+                                                  *centerLine == LaneMarking::DoubleSolid)) {
                         *centerLine = LaneMarking::DoubleSolid;
                         selection.changed = true;
-                    } else if (ImGui::RadioButton("Dashed and solid", *centerLine == LaneMarking::DashedAndSolid)) {
+                    } else if (ImGui::RadioButton("Dashed and solid",
+                                                  *centerLine == LaneMarking::DashedAndSolid)) {
                         *centerLine = LaneMarking::DashedAndSolid;
                         selection.changed = true;
-                    } else if (ImGui::RadioButton("Solid and dashed", *centerLine == LaneMarking::SolidAndDashed)) {
+                    } else if (ImGui::RadioButton("Solid and dashed",
+                                                  *centerLine == LaneMarking::SolidAndDashed)) {
                         *centerLine = LaneMarking::SolidAndDashed;
                         selection.changed = true;
+                    } else if (ImGui::RadioButton("Missing", *centerLine == LaneMarking::Missing)) {
+                        *centerLine = LaneMarking::Missing;
+                        selection.changed = true;
                     }
+                    ImGui::PopID();
+                }
+
+                if (leftLineMissing && rightLineMissing) {
+                    ImGui::PushID("OuterLines");
+                    ImGui::Text("Outer lines");
+                    selection.changed |= ImGui::Checkbox("Hide left line",leftLineMissing);
+                    selection.changed |= ImGui::Checkbox("Hide right line",rightLineMissing);
+                    ImGui::PopID();
                 }
             }
 

--- a/src/scene/Tracks.h
+++ b/src/scene/Tracks.h
@@ -18,11 +18,15 @@ struct ControlPoint {
     ControlPoint(glm::vec2 coords);
 };
 
+/**
+ * Describes the possible line types for the center line of a track.
+ */
 enum struct LaneMarking {
     Dashed,
     DoubleSolid,
     DashedAndSolid,
-    SolidAndDashed // same as above but with reversed order
+    SolidAndDashed, // same as above but with reversed order,
+    Missing
 };
 
 struct TrackBase {
@@ -41,7 +45,9 @@ struct TrackLine : TrackBase {
     std::weak_ptr<ControlPoint> start;
     std::weak_ptr<ControlPoint> end;
 
-    LaneMarking centerLine{LaneMarking::Dashed};
+    LaneMarking centerLine = LaneMarking::Dashed;
+    bool rightLineMissing = false;
+    bool leftLineMissing = false;
 
     TrackLine(const std::shared_ptr<ControlPoint>& start, const std::shared_ptr<ControlPoint>& end);
 
@@ -61,7 +67,9 @@ struct TrackArc : TrackBase {
     float radius{0};
     bool rightArc{false};
 
-    LaneMarking centerLine{LaneMarking::Dashed};
+    LaneMarking centerLine = LaneMarking::Dashed;
+    bool rightLineMissing = false;
+    bool leftLineMissing = false;
 
     TrackArc(const std::shared_ptr<ControlPoint>& start, const std::shared_ptr<ControlPoint>& end,
             const glm::vec2& center, const float radius, const bool rightArc);


### PR DESCRIPTION
Follow-up of #7 to improve the possible line types further.

Changes:
 - minor whitespace fixes
 - track lines can now be easily hidden in the track interface

![grafik](https://user-images.githubusercontent.com/45536968/196518250-8b2771c8-bb31-437c-895f-c9464d85f1ee.png)

Note: 

This MR doesn't include any measures to avoid the construction of illegal courses (e.g. it is possible to hide all three lines).
For now, we expect the user to handle the new feature with care as the check is more difficult than requiring one out of three lines being visible (the rulebook specifies a maximum length for two missing lines which could span over more than one segment).

Loading a new config with an older version of the simulator is possible and will cause the usage of the defaults (dashed line, no missing outer lines)
