### PR TITLE
fix: ortho cam movement & scene loading

### DIFF
--- a/src/Loop.cpp
+++ b/src/Loop.cpp
@@ -194,35 +194,31 @@ void Loop::step(Scene& scene, float frameDeltaTime) {
         }
     }
 
+    float aspectRatio = (float)settings.windowWidth / (float)settings.windowHeight;
+    switch(selectedCamera) {
+        case FPS_CAMERA:
+            scene.fpsCamera.aspectRatio = aspectRatio;
+            break;
+        case FOLLOW_CAMERA:
+            scene.followCamera.aspectRatio = aspectRatio;
+            break;
+        case CINEMATIC_CAMERA:
+            scene.cinematicCamera.aspectRatio = aspectRatio;
+            break;
+        case ORTHO_CAMERA:
+            scene.orthoCamera.aspectRatio = aspectRatio;
+            break;
+        default:
+            break;
+    }
+
     if (FPS_CAMERA == selectedCamera) {
-
-        scene.fpsCamera.aspectRatio = 
-            (float)settings.windowWidth / (float)settings.windowHeight;
-
         if (settings.showMarkers) {
             markerModule.update(window, scene.fpsCamera, scene.selection);
             editor.updateInput(scene.fpsCamera, scene.tracks, scene.groundSize);
         }
 
         itemsModule.update(scene.items, scene.selection.pose);
-    }
-
-    if (FOLLOW_CAMERA == selectedCamera) {
-
-        scene.followCamera.aspectRatio = 
-            (float)settings.windowWidth / (float)settings.windowHeight;
-    }
-
-    if (CINEMATIC_CAMERA == selectedCamera) {
-
-        scene.cinematicCamera.aspectRatio =
-                (float) settings.windowWidth / (float) settings.windowHeight;
-    }
-
-    if (ORTHO_CAMERA == selectedCamera) {
-
-        scene.orthoCamera.aspectRatio =
-                (float)settings.windowWidth / (float)settings.windowHeight;
     }
 
     // actual simulation updates

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -727,8 +727,12 @@ void from_json(const json& j, Scene& s) {
     s.car = j.at("car").get<Car>();
     s.tracks = j.at("tracks").get<Tracks>();
     s.items = j.at("items").get<std::vector<Scene::Item>>();
-    s.orthoCamera = j.at("orthoCamera").get<OrthoCamera>();
 
+    try {
+        s.orthoCamera = j.at("orthoCamera").get<OrthoCamera>();
+    } catch (std::exception& e) {
+        std::cout << "Loading defaults for OrthoCamera" << std::endl;
+    }
 
     try {
         s.rules = j.at("rules").get<Scene::Rules>();

--- a/src/helpers/FpsCamera.cpp
+++ b/src/helpers/FpsCamera.cpp
@@ -57,7 +57,7 @@ void FpsCamera::update(GLFWwindow* window, float dt) {
     if (GLFW_PRESS == getKey(GLFW_KEY_LEFT_SHIFT)) {
         pose.position -= up * speed;
     }
-    
+
     int rightMouseBtnState = getMouseButton(GLFW_MOUSE_BUTTON_RIGHT);
 
     if (GLFW_PRESS == rightMouseBtnState) {
@@ -66,11 +66,18 @@ void FpsCamera::update(GLFWwindow* window, float dt) {
         glfwGetCursorPos(window, &mouseX, &mouseY);
 
         if (prevMouseX > 0 && prevMouseY > 0) {
+            float old_pitch = pitch;
+            float old_yaw = yaw;
 
             pitch += std::asin(((float)mouseY - prevMouseY) * dt);
             pitch = std::min(1.56f, std::max(-1.56f, pitch));
 
             yaw += std::asin(((float)mouseX - prevMouseX) * dt);
+
+            if (std::isnan(pitch) || std::isnan(yaw)) {
+                pitch = old_pitch;
+                yaw = old_yaw;
+            }
         }
 
         prevMouseX = (float)mouseX;

--- a/src/helpers/FpsCamera.cpp
+++ b/src/helpers/FpsCamera.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "FpsCamera.h"
 
 FpsCamera::FpsCamera() {
@@ -66,18 +67,10 @@ void FpsCamera::update(GLFWwindow* window, float dt) {
         glfwGetCursorPos(window, &mouseX, &mouseY);
 
         if (prevMouseX > 0 && prevMouseY > 0) {
-            float old_pitch = pitch;
-            float old_yaw = yaw;
+            pitch += std::asin(std::clamp(((float)mouseY - prevMouseY) * dt, -1.0f, 1.0f));
+            pitch = std::clamp(pitch, -1.56f, 1.56f);
 
-            pitch += std::asin(((float)mouseY - prevMouseY) * dt);
-            pitch = std::min(1.56f, std::max(-1.56f, pitch));
-
-            yaw += std::asin(((float)mouseX - prevMouseX) * dt);
-
-            if (std::isnan(pitch) || std::isnan(yaw)) {
-                pitch = old_pitch;
-                yaw = old_yaw;
-            }
+            yaw += std::asin(std::clamp(((float)mouseX - prevMouseX) * dt, -1.0f, 1.0f));
         }
 
         prevMouseX = (float)mouseX;

--- a/src/helpers/OrthoCamera.cpp
+++ b/src/helpers/OrthoCamera.cpp
@@ -69,7 +69,13 @@ void OrthoCamera::update(GLFWwindow* window, float dt) {
         glfwGetCursorPos(window, &mouseX, &mouseY);
 
         if (prevMouseX > 0) {
+            float old_yaw = yaw;
+
             yaw += std::asin(((float)mouseX - prevMouseX) * dt);
+
+            if (std::isnan(yaw)) {
+                yaw = old_yaw;
+            }
         }
 
         prevMouseX = (float)mouseX;

--- a/src/helpers/OrthoCamera.cpp
+++ b/src/helpers/OrthoCamera.cpp
@@ -25,7 +25,7 @@ void OrthoCamera::update(GLFWwindow* window, float dt) {
     glm::mat4 view = pose.getInverseMatrix();
 
     glm::vec3 eye = glm::normalize(
-            glm::vec3(view[0][2], 0.0f, view[2][2]));
+            glm::vec3(view[0][1], 0.0f, view[2][1]));
 
     glm::vec3 right = glm::normalize(
             glm::vec3(view[0][0], 0.0f, view[2][0]));
@@ -43,13 +43,13 @@ void OrthoCamera::update(GLFWwindow* window, float dt) {
     }
 
     if (GLFW_PRESS == getKey(GLFW_KEY_W)) {
-        pose.position -= eye * speed;
+        pose.position += eye * speed;
     }
     if (GLFW_PRESS == getKey(GLFW_KEY_A)) {
         pose.position -= right * speed;
     }
     if (GLFW_PRESS == getKey(GLFW_KEY_S)) {
-        pose.position += eye * speed;
+        pose.position -= eye * speed;
     }
     if (GLFW_PRESS == getKey(GLFW_KEY_D)) {
         pose.position += right * speed;

--- a/src/helpers/OrthoCamera.cpp
+++ b/src/helpers/OrthoCamera.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "OrthoCamera.h"
 
 glm::mat4 OrthoCamera::getProjectionMatrix() {
@@ -69,13 +70,7 @@ void OrthoCamera::update(GLFWwindow* window, float dt) {
         glfwGetCursorPos(window, &mouseX, &mouseY);
 
         if (prevMouseX > 0) {
-            float old_yaw = yaw;
-
-            yaw += std::asin(((float)mouseX - prevMouseX) * dt);
-
-            if (std::isnan(yaw)) {
-                yaw = old_yaw;
-            }
+            yaw += std::asin(std::clamp(((float)mouseX - prevMouseX) * dt, -1.0f, 1.0f));
         }
 
         prevMouseX = (float)mouseX;


### PR DESCRIPTION
Contains the following fixes:
- older scene saves which do not already contain the fields for `orthoCamera` will load with the defaults instead of segfaulting
- ortho cam vertical movement (W / S) has been fixed to respect the rotation of the camera
- FPS and ortho cam can no longer end up in a broken state due to `NaN` yaw/pitch values (caused by "fast" mouse movement)