### PR TITLE
fix: reuse buffers to work with intel

### DIFF
--- a/src/helpers/Capture.cpp
+++ b/src/helpers/Capture.cpp
@@ -28,7 +28,7 @@ bool Capture::capture(
 
     if (pboWidth != width || pboHeight != height) {
         pboHeight = height;
-        pboHeight = width;
+        pboWidth = width;
         glBindBuffer(GL_PIXEL_PACK_BUFFER, pboIds[0]);
         glBufferData(GL_PIXEL_PACK_BUFFER, dataSize, nullptr, GL_STREAM_READ);
         glBindBuffer(GL_PIXEL_PACK_BUFFER, pboIds[1]);


### PR DESCRIPTION
correctly reuse pbo buffer data to work with intel
(why did it actually work with nvidia?)